### PR TITLE
Default javascript runtime

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gem "capybara", ">= 1.0.0", :group => :test
 gem "database_cleaner", ">= 0.6.7", :group => :test
 gem "launchy", ">= 2.0.5", :group => :test
 gem "devise", ">= 1.4.2"
+gem "therubyracer", "0.9.4" # default javascript runtime for execjs 


### PR DESCRIPTION
Hi, 

I'm trying this project and get error when  running "rake db:migrate" (it said I had no javascript runtime). From this topic http://stackoverflow.com/questions/6282307/rails-3-1-execjs-and-could-not-find-a-javascript-runtime,  I figured out that I didn't install any javascript runtime but it requires any runtime must be installed in Gemfile. 

So I just add the default one in Gemfile
