### PR TITLE
Disable DELETE-based logouts only in the test environment

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -185,7 +185,7 @@ Devise.setup do |config|
   # config.navigational_formats = [:"*/*", "*/*", :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :get
+  config.sign_out_via = Rails.env.test? ? :get : :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
DELETE-based logouts make more sense, as explained by José Valim. To make Cucumber work, we can only use GET-based logouts in the test environment.
