### PR TITLE
Add extra scenarios to the edit user feature

### DIFF
--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -121,11 +121,50 @@ When /^I sign in with a wrong password$/ do
   sign_in
 end
 
-When /^I edit my account details$/ do
+When(/^I save the edit form$/) do
+  click_button "Update"
+end
+
+When /^I edit my account name$/ do
   click_link "Edit account"
   fill_in "user_name", :with => "newname"
   fill_in "user_current_password", :with => @visitor[:password]
-  click_button "Update"
+end
+
+When /^I edit my email address$/ do
+  click_link "Edit account"
+  fill_in "user_email", :with => "newemail@example.com"
+  fill_in "user_current_password", :with => @visitor[:password]
+end
+
+When(/^I don't enter my current password$/) do
+  fill_in "user_current_password", :with => ""
+end
+
+When(/^I edit my email address with an invalid email$/) do
+  click_link "Edit account"
+  fill_in "user_email", :with => "notanemail"
+  fill_in "user_current_password", :with => @visitor[:password]
+end
+
+When(/^I edit my password$/) do
+  click_link "Edit account"
+  fill_in "user_password", :with => "newpassword"
+  fill_in "user_password_confirmation", :with => "newpassword"
+  fill_in "user_current_password", :with => @visitor[:password]
+end
+
+When(/^I edit my password with missing confirmation$/) do
+  click_link "Edit account"
+  fill_in "user_password", :with => "newpassword"
+  fill_in "user_current_password", :with => @visitor[:password]
+end
+
+When(/^I edit my password with missmatched confirmation$/) do
+  click_link "Edit account"
+  fill_in "user_password", :with => "newpassword"
+  fill_in "user_password_confirmation", :with => "newpassword123"
+  fill_in "user_current_password", :with => @visitor[:password]
 end
 
 When /^I look at the list of users$/ do
@@ -183,6 +222,10 @@ end
 
 Then /^I should see an account edited message$/ do
   page.should have_content "You updated your account successfully."
+end
+
+Then(/^I should see a current password missing message$/) do
+  page.should have_content "Current password can't be blank"
 end
 
 Then /^I should see my name$/ do

--- a/features/users/user_edit.feature
+++ b/features/users/user_edit.feature
@@ -3,7 +3,45 @@ Feature: Edit User
   I want to edit my user profile
   so I can change my username
 
-    Scenario: I sign in and edit my account
+    Scenario: I sign in and edit my name
       Given I am logged in
-      When I edit my account details
+      When I edit my account name
+      And I save the edit form
       Then I should see an account edited message
+
+    Scenario: I sign in and edit my email address
+      Given I am logged in
+      When I edit my email address
+      And I save the edit form
+      Then I should see an account edited message
+
+    Scenario: I edit my account without current password
+      Given I am logged in
+      When I edit my email address
+      And I don't enter my current password
+      And I save the edit form
+      Then I should see a current password missing message
+
+    Scenario: I sign in and edit with invalid email
+      Given I am logged in
+      When I edit my email address with an invalid email
+      And I save the edit form
+      Then I should see an invalid email message
+
+    Scenario: I sign in and edit my password
+      Given I am logged in
+      When I edit my password
+      And I save the edit form
+      Then I should see an account edited message
+
+    Scenario: I sign in and edit my password with missing confirmation
+      Given I am logged in
+      When I edit my password with missing confirmation
+      And I save the edit form
+      Then I should see a mismatched password message
+
+    Scenario: I sign in and edit my password with mismatched confirmation
+      Given I am logged in
+      When I edit my password with missmatched confirmation
+      And I save the edit form
+      Then I should see a mismatched password message


### PR DESCRIPTION
The account editing feature seemed relatively sparse compared to the others so I extended it a little.
- Scenarios for editing email address and password
- Scenarios for error conditions on the edit form
